### PR TITLE
Fix reply attack in CAPTCHA

### DIFF
--- a/html/includes/signin.php
+++ b/html/includes/signin.php
@@ -9,9 +9,13 @@
             if ($_POST["login"] !== ADMIN_LOGIN_NAME)
                 $time_out = $error = !checkStartEndTime();
 
-            if (CAPTCHA_ENABLED)
+            if (CAPTCHA_ENABLED) {
                 if (!isset($_POST["captcha"]) || !isset($_SESSION["captcha_text"]) || strtoupper($_POST["captcha"]) !== strtoupper($_SESSION["captcha_text"]))
                     $wrong_captcha = $error = true;
+                
+                if (isset($_SESSION["captcha_text"]))
+                    unset($_SESSION["captcha_text"]);
+            }
 
             if (!$error) {
                 $rows = fetchAll("SELECT team_id, full_name, password_hash FROM teams WHERE login_name=:login", array("login" => $_POST["login"]));


### PR DESCRIPTION
At the moment it is possible to solve CAPTCHA just a single time and then repeat sign in requests multiple times with the same CAPTCHA solution. We only need to block further requests for CAPTCHA image to avoid overriding `$_SESSION["captcha_text"]` variable contents.

This PR is addressing this issue by unsetting `$_SESSION["captcha_text"]` after each validation, so the user must request for the next CAPTCHA image or further requests will fail unconditionally.